### PR TITLE
#1 Changed fields to being recommended fields for user pictures

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -381,10 +381,14 @@ class gradingform_multigraders_controller extends gradingform_controller {
         if(isset($this->definition->secondary_graders_id_list) &&
             $this->definition->secondary_graders_id_list != ''){
             //transform list of grader ids into name list
+
+            $mainuserfields = user_picture::fields();
+
             $dbUsers = get_users(true,'',true,null,'lastname ASC,firstname ASC',
-                $firstinitial='', $lastinitial='', $page=0, $recordsperpage=100, $fields='id,firstname,lastname',
+                $firstinitial='', $lastinitial='', $page=0, $recordsperpage=100, $fields=$mainuserfields,
                 $extraselect='id IN ('.$this->definition->secondary_graders_id_list.')');
             $secondaryGraders = '';
+
             foreach($dbUsers as $id => $oUser){
                 $secondaryGraders .= fullname($oUser).', ';
             }


### PR DESCRIPTION
This is a fix against Moodle 3.10+ which has additional name fields (https://docs.moodle.org/dev/Additional_name_fields).

As the plugin was using a fixed list of fields this then throws a warning message.

I've changed the hard coded list of fields in to the user_picture::fields() function as this leaves the option open to display more user information.