### PR TITLE
Fix #25 rubrics not shown

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -178,7 +178,7 @@
      clear: both;
  }
 
- #fitem_id_advancedgrading{
+ #gradingform_multigraders #fitem_id_advancedgrading{
     display: none;
  }
 


### PR DESCRIPTION
The version should be bumped to purge the cache to apply the updated CSS. I haven't done this as plugin maintainers never like it when I bump the version in pull requests.